### PR TITLE
LW-38195: Adds permissions to workflow

### DIFF
--- a/.github/workflows/version-and-pull-request.yml
+++ b/.github/workflows/version-and-pull-request.yml
@@ -2,7 +2,11 @@ name: Build and Publish nuget package (Manual Versioning)
 
 on:
   workflow_dispatch:
-
+    
+permissions:
+  contents: read
+  packages: write # Required for publishing
+  
 jobs:
   core-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specifies required permissions for the workflow, including read access to the repository contents and write access to packages, which is essential for publishing the NuGet package.
